### PR TITLE
docs: update README.md to include `sudo` in installer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The UEX 2.0 Command Line Interface offers an alternative interaction mode with t
 ## Installation
 
     // via installer
-    $ curl -sSL https://raw.githubusercontent.com/uexcorp/uex-cli/main/install.sh | bash 
+    $ curl -sSL https://raw.githubusercontent.com/uexcorp/uex-cli/main/install.sh | sudo bash 
     $ uex   
 
 or:  


### PR DESCRIPTION
The installer attempts to place the `uex-cli.sh` script in `/usr/local/bin` which can only be accessed as super user.

![image](https://github.com/user-attachments/assets/9cb98610-62c8-48cc-b466-126a445d9d7c)
